### PR TITLE
Added missing CodeChickenLib dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ repositories {
 }
 
 dependencies {
+    compile group: 'codechicken', name: 'CodeChickenLib', version: "${config.version.minecraft}-${config.version.ccl}", ext: 'jar', classifier: "dev"
     compile group: 'codechicken', name: 'NotEnoughItems', version: "${config.version.minecraft}-${config.version.nei}", ext: 'jar', classifier: "dev"
     compile group: 'codechicken', name: 'CodeChickenCore', version: "${config.version.minecraft}-${config.version.cccore}", ext: 'jar', classifier: "dev"
     compile fileTree(dir: 'libs', include: '*.jar')

--- a/build.properties
+++ b/build.properties
@@ -4,3 +4,4 @@ version.minecraft=1.7.10
 version.mod.major=1
 version.mod.minor=0
 version.nei=1.0.5.110
+version.ccl=1.1.3.138


### PR DESCRIPTION
The runClient and runServer forge tasks would not start with ClassNotFoundExceptions. Adding this dependency fixes the issue.